### PR TITLE
Change Fluid Amount Formatting and Request Amounts When Scrolling

### DIFF
--- a/src/main/java/com/yision/fluidlogistics/mixin/client/StockKeeperRequestScreenMixin.java
+++ b/src/main/java/com/yision/fluidlogistics/mixin/client/StockKeeperRequestScreenMixin.java
@@ -434,7 +434,7 @@ public abstract class StockKeeperRequestScreenMixin {
         }
 
         int current = existingOrder.count;
-        int newAmount = FluidAmountHelper.adjustFluidRequestAmount(current, forward, Screen.hasShiftDown(),
+        int newAmount = FluidAmountHelper.adjustStockTickerFluidRequestAmount(current, forward, Screen.hasShiftDown(),
             Screen.hasControlDown(), 0, Math.max(0, maxAvailable), steps);
         if (newAmount <= 0) {
             itemsToOrder.remove(existingOrder);

--- a/src/main/java/com/yision/fluidlogistics/mixin/client/StockKeeperRequestScreenMixin.java
+++ b/src/main/java/com/yision/fluidlogistics/mixin/client/StockKeeperRequestScreenMixin.java
@@ -1,7 +1,32 @@
 package com.yision.fluidlogistics.mixin.client;
 
-import java.util.List;
-
+import com.llamalad7.mixinextras.sugar.Local;
+import com.simibubi.create.content.logistics.BigItemStack;
+import com.simibubi.create.content.logistics.packager.InventorySummary;
+import com.simibubi.create.content.logistics.stockTicker.CraftableBigItemStack;
+import com.simibubi.create.content.logistics.stockTicker.StockKeeperRequestMenu;
+import com.simibubi.create.content.logistics.stockTicker.StockKeeperRequestScreen;
+import com.simibubi.create.content.logistics.stockTicker.StockTickerBlockEntity;
+import com.simibubi.create.foundation.gui.menu.AbstractSimiContainerScreen;
+import com.simibubi.create.foundation.utility.CreateLang;
+import com.yision.fluidlogistics.item.CompressedTankItem;
+import com.yision.fluidlogistics.render.FluidSlotAmountRenderer;
+import com.yision.fluidlogistics.util.FluidAmountHelper;
+import com.yision.fluidlogistics.util.FluidGaugeHelper;
+import com.yision.fluidlogistics.util.IFluidCraftableBigItemStack;
+import net.createmod.catnip.data.Couple;
+import net.createmod.catnip.data.Pair;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.neoforged.neoforge.fluids.FluidStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -11,28 +36,11 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import com.simibubi.create.content.logistics.BigItemStack;
-import com.simibubi.create.content.logistics.packager.InventorySummary;
-import com.simibubi.create.content.logistics.stockTicker.CraftableBigItemStack;
-import com.simibubi.create.content.logistics.stockTicker.StockKeeperRequestScreen;
-import com.simibubi.create.content.logistics.stockTicker.StockTickerBlockEntity;
-import com.yision.fluidlogistics.item.CompressedTankItem;
-import com.yision.fluidlogistics.render.FluidSlotAmountRenderer;
-import com.yision.fluidlogistics.util.FluidAmountHelper;
-import com.yision.fluidlogistics.util.IFluidCraftableBigItemStack;
-
-import net.createmod.catnip.data.Couple;
-import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.util.Mth;
-import net.neoforged.neoforge.fluids.FluidStack;
-import net.createmod.catnip.data.Pair;
+import java.util.ArrayList;
+import java.util.List;
 
 @Mixin(StockKeeperRequestScreen.class)
-public abstract class StockKeeperRequestScreenMixin {
+public abstract class StockKeeperRequestScreenMixin extends AbstractSimiContainerScreen<StockKeeperRequestMenu> {
 
     @Shadow(remap = false)
     public List<BigItemStack> itemsToOrder;
@@ -48,6 +56,10 @@ public abstract class StockKeeperRequestScreenMixin {
 
     @Shadow(remap = false)
     private boolean canRequestCraftingPackage;
+
+    public StockKeeperRequestScreenMixin(StockKeeperRequestMenu container, Inventory inv, Component title) {
+        super(container, inv, title);
+    }
 
     @Shadow(remap = false)
     protected abstract BigItemStack getOrderForItem(ItemStack stack);
@@ -262,6 +274,34 @@ public abstract class StockKeeperRequestScreenMixin {
         }
     }
 
+    @Redirect(method = "renderForeground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;renderComponentTooltip(Lnet/minecraft/client/gui/Font;Ljava/util/List;II)V", ordinal = 0))
+    private void fluidlogistics$recipeTooltip(GuiGraphics graphics, Font font, List<Component> tooltipLines, int mouseX, int mouseY, @Local(name = "lines")
+        ArrayList<Component> lines, @Local(name = "entry") BigItemStack entry){
+        // handles adding the fluid amount to the tooltip for recipes only
+        if (FluidGaugeHelper.isVirtualFluidFilter(entry.stack)) {
+            String amountText = FluidAmountHelper.formatPrecise(entry.count);
+            lines.add(1, CreateLang.text(amountText)
+                    .style(ChatFormatting.DARK_GRAY)
+                    .component());
+        }
+        graphics.renderComponentTooltip(font, lines, mouseX, mouseY);
+    }
+
+    @Redirect(method="renderForeground", at = @At(value="INVOKE",target = "Lnet/minecraft/client/gui/GuiGraphics;renderTooltip(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;II)V",ordinal = 0))
+    private void fluidlogistics$itemTooltip(GuiGraphics graphics, Font font, ItemStack stack, int mouseX, int mouseY, @Local(name = "entry") BigItemStack entry){
+        // handles adding the fluid amount to the tooltip for items (everything else)
+        if (FluidGaugeHelper.isVirtualFluidFilter(entry.stack)) {
+            ArrayList<Component> lines = new ArrayList<>(entry.stack.getTooltipLines(Item.TooltipContext.of(minecraft.level), minecraft.player, TooltipFlag.NORMAL));
+            String amountText = FluidAmountHelper.formatPrecise(entry.count);
+            lines.add(1, CreateLang.text(amountText)
+                    .style(ChatFormatting.DARK_GRAY)
+                    .component());
+            graphics.renderComponentTooltip(font, lines, mouseX, mouseY);
+            return;
+        }
+        graphics.renderTooltip(font, entry.stack, mouseX, mouseY);
+    }
+
     @Unique
     private void fluidlogistics$updateCraftableAmountsWithCustomEntries() {
         InventorySummary usedItems = new InventorySummary();
@@ -432,10 +472,16 @@ public abstract class StockKeeperRequestScreenMixin {
             existingOrder = new BigItemStack(entry.stack.copyWithCount(1), 0);
             itemsToOrder.add(existingOrder);
         }
-
+        int newAmount;
         int current = existingOrder.count;
-        int newAmount = FluidAmountHelper.adjustStockTickerFluidRequestAmount(current, forward, Screen.hasShiftDown(),
-            Screen.hasControlDown(), 0, Math.max(0, maxAvailable), steps);
+
+        if (orderClicked){
+            newAmount = FluidAmountHelper.adjustFluidRequestAmount(current, forward, Screen.hasShiftDown(),
+                    Screen.hasControlDown(), 0, Math.max(0, maxAvailable), steps);
+        } else {
+            newAmount = FluidAmountHelper.adjustStockTickerFluidRequestAmount(current, forward, Screen.hasShiftDown(),
+                    Screen.hasControlDown(), 0, Math.max(0, maxAvailable), steps);
+        }
         if (newAmount <= 0) {
             itemsToOrder.remove(existingOrder);
             return;

--- a/src/main/java/com/yision/fluidlogistics/portableticker/PortableStockTickerScreen.java
+++ b/src/main/java/com/yision/fluidlogistics/portableticker/PortableStockTickerScreen.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import com.yision.fluidlogistics.util.FluidGaugeHelper;
+import net.minecraft.client.gui.screens.Screen;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
@@ -577,17 +579,27 @@ public class PortableStockTickerScreen extends AbstractSimiContainerScreen<Porta
         BigItemStack entry = getEntryAt(hoveredSlot);
 
         ItemStack stack = entry.stack;
-        if (recipeHovered) {
-            ArrayList<Component> lines = new ArrayList<>(
-                    stack.getTooltipLines(TooltipContext.of(minecraft.level), minecraft.player, TooltipFlag.NORMAL));
-            if (!lines.isEmpty()) {
-                lines.set(0, CreateLang.translateDirect("gui.stock_keeper.craft", lines.getFirst().copy()));
-            }
-            graphics.renderComponentTooltip(font, lines, mouseX, mouseY);
+
+        if (!FluidGaugeHelper.isVirtualFluidFilter(stack) && !recipeHovered){
+            graphics.renderTooltip(font, stack, mouseX, mouseY);
             return;
         }
 
-        graphics.renderTooltip(font, stack, mouseX, mouseY);
+        ArrayList<Component> lines = new ArrayList<>(
+                stack.getTooltipLines(TooltipContext.of(minecraft.level), minecraft.player, TooltipFlag.NORMAL));
+
+        if (FluidGaugeHelper.isVirtualFluidFilter(stack) && !lines.isEmpty()){
+            String amountText = FluidAmountHelper.formatPrecise(entry.count);
+            lines.add(1, CreateLang.text(amountText)
+                    .style(ChatFormatting.DARK_GRAY)
+                    .component());
+        }
+
+        if (recipeHovered && !lines.isEmpty()) {
+            lines.set(0, CreateLang.translateDirect("gui.stock_keeper.craft", lines.getFirst().copy()));
+        }
+
+        graphics.renderComponentTooltip(font, lines, mouseX, mouseY);
     }
 
     private void renderItemEntry(GuiGraphics graphics, BigItemStack entry, boolean isStackHovered,
@@ -1264,8 +1276,15 @@ public class PortableStockTickerScreen extends AbstractSimiContainerScreen<Porta
             }
         }
 
-        int newAmount = FluidAmountHelper.adjustStockTickerFluidRequestAmount(existingOrder.count, forward, hasShiftDown(),
-                hasControlDown(), 0, Math.max(0, maxAvailable), steps);
+        int newAmount;
+
+        if (orderClicked){
+            newAmount = FluidAmountHelper.adjustFluidRequestAmount(existingOrder.count, forward, Screen.hasShiftDown(),
+                    Screen.hasControlDown(), 0, Math.max(0, maxAvailable), steps);
+        } else {
+            newAmount = FluidAmountHelper.adjustStockTickerFluidRequestAmount(existingOrder.count, forward, hasShiftDown(),
+                    hasControlDown(), 0, Math.max(0, maxAvailable), steps);
+        }
         if (newAmount <= 0) {
             itemsToOrder.remove(existingOrder);
             if (playFeedback) {

--- a/src/main/java/com/yision/fluidlogistics/portableticker/PortableStockTickerScreen.java
+++ b/src/main/java/com/yision/fluidlogistics/portableticker/PortableStockTickerScreen.java
@@ -1264,7 +1264,7 @@ public class PortableStockTickerScreen extends AbstractSimiContainerScreen<Porta
             }
         }
 
-        int newAmount = FluidAmountHelper.adjustFluidRequestAmount(existingOrder.count, forward, hasShiftDown(),
+        int newAmount = FluidAmountHelper.adjustStockTickerFluidRequestAmount(existingOrder.count, forward, hasShiftDown(),
                 hasControlDown(), 0, Math.max(0, maxAvailable), steps);
         if (newAmount <= 0) {
             itemsToOrder.remove(existingOrder);

--- a/src/main/java/com/yision/fluidlogistics/util/FluidAmountHelper.java
+++ b/src/main/java/com/yision/fluidlogistics/util/FluidAmountHelper.java
@@ -91,13 +91,8 @@ public final class FluidAmountHelper {
 
     public static int adjustFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,
             int minAmount, int maxAmount) {
-        return adjustFluidRequestAmount(currentAmount, forward, shift, control, minAmount, maxAmount, 1);
-    }
-
-    public static int adjustFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,
-            int minAmount, int maxAmount, int steps) {
         int delta = getFluidRequestStep(shift, control) * (forward? 1:-1);
-        return adjustFluidRequestAmount(currentAmount, delta, minAmount, maxAmount,steps);
+        return adjustFluidRequestAmount(currentAmount, delta, minAmount, maxAmount,1);
     }
 
     public static int adjustStockTickerFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,

--- a/src/main/java/com/yision/fluidlogistics/util/FluidAmountHelper.java
+++ b/src/main/java/com/yision/fluidlogistics/util/FluidAmountHelper.java
@@ -90,9 +90,14 @@ public final class FluidAmountHelper {
     }
 
     public static int adjustFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,
-            int minAmount, int maxAmount) {
+            int minAmount, int maxAmount, int steps) {
         int delta = getFluidRequestStep(shift, control) * (forward? 1:-1);
-        return adjustFluidRequestAmount(currentAmount, delta, minAmount, maxAmount,1);
+        return adjustFluidRequestAmount(currentAmount, delta, minAmount, maxAmount,steps);
+    }
+
+    public static int adjustFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,
+            int minAmount, int maxAmount) {
+        return adjustFluidRequestAmount(currentAmount, forward, shift, control, minAmount, maxAmount,1);
     }
 
     public static int adjustStockTickerFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,

--- a/src/main/java/com/yision/fluidlogistics/util/FluidAmountHelper.java
+++ b/src/main/java/com/yision/fluidlogistics/util/FluidAmountHelper.java
@@ -46,7 +46,7 @@ public final class FluidAmountHelper {
     }
 
     public static String formatStockKeeper(int amount) {
-        return formatPrecise(amount);
+        return format(amount);
     }
 
     public static String formatDetailed(int amount) {
@@ -96,26 +96,26 @@ public final class FluidAmountHelper {
 
     public static int adjustFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,
             int minAmount, int maxAmount, int steps) {
-        int newAmount = currentAmount;
-        int safeSteps = Math.max(0, steps);
-        for (int i = 0; i < safeSteps; i++) {
-            newAmount = adjustFluidRequestAmountOnce(newAmount, forward, shift, control, minAmount, maxAmount);
-        }
-
-        return newAmount;
+        int delta = getFluidRequestStep(shift, control) * (forward? 1:-1);
+        return adjustFluidRequestAmount(currentAmount, delta, minAmount, maxAmount,steps);
     }
 
-    private static int adjustFluidRequestAmountOnce(int currentAmount, boolean forward, boolean shift, boolean control,
-            int minAmount, int maxAmount) {
-        int delta = getFluidRequestStep(shift, control);
-        int newAmount = currentAmount + (forward ? delta : -delta);
+    public static int adjustStockTickerFluidRequestAmount(int currentAmount, boolean forward, boolean shift, boolean control,
+            int minAmount, int maxAmount, int steps){
+        int delta = getStockTickerFluidRequestStep(shift, control) * (forward? 1:-1);
+        return adjustFluidRequestAmount(currentAmount, delta, minAmount, maxAmount,steps);
+    }
 
-        if (forward) {
-            if (currentAmount < MB_PER_TENTH_BUCKET && newAmount >= MB_PER_TENTH_BUCKET && newAmount < MB_PER_BUCKET) {
-                newAmount = MB_PER_TENTH_BUCKET;
-            } else if (currentAmount < MB_PER_BUCKET && newAmount >= MB_PER_BUCKET) {
-                newAmount = MB_PER_BUCKET;
-            }
+    private static int adjustFluidRequestAmount(int currentAmount, int delta, int minAmount, int maxAmount, int steps) {
+        int safeSteps = Math.max(0, steps);
+        int newAmount;
+
+        if (currentAmount == 1 && delta>1){
+            //fluid inputs start with 1mb. This check stops the first scroll (ex 1B) from going to 1.001B and instead going to 1B exactly
+            //need to also check delta>1 or else ctrl+scroll doesn't work when currentAmount == 1
+            newAmount = delta * safeSteps;
+        } else {
+            newAmount = currentAmount + delta * safeSteps;
         }
 
         return Math.clamp(newAmount, minAmount, maxAmount);
@@ -127,6 +127,12 @@ public final class FluidAmountHelper {
         }
         if (shift) {
             return MB_PER_TENTH_BUCKET;
+        }
+        return MB_PER_BUCKET;
+    }
+    private static int getStockTickerFluidRequestStep(boolean shift, boolean control) {
+        if (control) {
+            return 10*MB_PER_BUCKET;
         }
         return MB_PER_BUCKET;
     }
@@ -181,7 +187,14 @@ public final class FluidAmountHelper {
         if (amount >= unitSize && amount % unitSize == 0) {
             return (amount / unitSize) + suffix;
         }
-        double value = Math.floor(amount / (unitSize / 10.0)) / 10.0;
-        return String.format(Locale.ROOT, "%.1f%s", value, suffix);
+        if (amount / unitSize <= 10) {
+            //only one digit before decimal
+            //display 1 decimal
+            double value = Math.floor(amount / (unitSize / 10.0)) / 10.0;
+            return String.format(Locale.ROOT, "%.1f%s", value, suffix);
+
+        }
+        // don't display decimal
+        return String.format(Locale.ROOT, "%.0f%s", Math.floor(amount / (float) unitSize), suffix);
     }
 }

--- a/src/main/resources/assets/fluidlogistics/lang/en_us.json
+++ b/src/main/resources/assets/fluidlogistics/lang/en_us.json
@@ -9,7 +9,7 @@
   "block.fluidlogistics.multi_fluid_access_port.filter_left": "Left Fluid Filter",
   "block.fluidlogistics.multi_fluid_access_port.filter_right": "Right Fluid Filter",
   "block.fluidlogistics.multi_fluid_access_port.filter_back": "Back Fluid Filter",
-  "block.fluidlogistics.waterproof_cardboard_block": "Waterproof Cardboard Block",
+  "block.fluidlogistics.waterproof_cardboard_block": "Waterproof Block of Cardboard",
   "block.fluidlogistics.multi_fluid_tank": "Multi-Fluid Tank",
   "block.fluidlogistics.horizontal_multi_fluid_tank": "Horizontal Multi-Fluid Tank",
   "block.fluidlogistics.infinite_fluid_tank": "Infinite Fluid Tank",


### PR DESCRIPTION
## Fluid Amount Formatting
The changes are so that when using `format()` the resulting string will be 5 characters or less. This change results in fluid amount text overlapping much less and overall fitting the UI much better. Generally, if the fluid amount would have only one number before the decimal, than 1 decimal is show. If two or more numbers would be before the decimal than it is rounded. Exact mb amounts are only shown below 100mb.

Fluid amounts in tooltips are unchanged and still show the exact amount

### As comparason:
Before: 
<img width="861" height="553" alt="Screenshot 2026-05-18 150627" src="https://github.com/user-attachments/assets/448b1a81-a5de-460b-8ee9-8434fb08a604" />

After:
<img width="852" height="541" alt="Screenshot 2026-05-18 145959" src="https://github.com/user-attachments/assets/40fac2ee-4bb9-4de3-a7df-3ce84f34361a" />

## Fluid Request Amounts When Scrolling

From what I can tell most of the logic in the old `adjustFluidRequestAmountOnce` is to make it so that the first scroll results in the desired fluid amount and not 1mb over. So for example the first scroll of 1B results in setting exactly 1B, because without that logic it would be 1.001B. If this is its only purpose it can be replaced with much simpler logic (as I have done).

It also seems like the for loop in `adjustFluidRequestAmount` can be replaced by just multiplying the scroll delta by the number of safe steps without actually looping any code. It also looks like the only time the `steps` variable is anything but 1 is because of calls related to the stock ticker in two places:
https://github.com/yision1/CreateFluidLogistic/blob/512226db3facd2f2ea0ab5261895c2fbdf648b5a/src/main/java/com/yision/fluidlogistics/mixin/client/StockKeeperRequestScreenMixin.java#L184
https://github.com/yision1/CreateFluidLogistic/blob/512226db3facd2f2ea0ab5261895c2fbdf648b5a/src/main/java/com/yision/fluidlogistics/portableticker/PortableStockTickerScreen.java#L969
From my testing I could never get `steps` to be anything but 1 so I dont understand why it exhists. The majority of the calls hardcode `steps=1`.


In general, from what I can tell my new coded is functionally the same but alot cleaner.
If I misunderstood any of the old functionality please let me know.

The last change is in how the fluid scroll amounts are handled in the stock ticker. Because of the way the stock ticker works, you have to hold shift in order to change request amounts (not holding shift results in just scrolling down the stock ticker list. the only time you can not be holding shift is if there arent enough items in the gui so the scroll bar isnt there). As a result of this the old code would only allow adjustment in 100mb or 1mb. The new code allows for adjustment in 1B for shift+scroll and 10B for ctrl+shift+scroll. I dont know if the way I implemented it is ok for code quality but I couldnt think of a cleaner way to do it.

## Lang Change
The last change is renaming waterproof cardboard to better match how create cardboard and create bound cardboard are named

 