### PR TITLE
Kaleidoscope tavern 1.2.0+ compat | 森罗酒馆 1.2.0+ 兼容

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,5 +33,5 @@ emi_version=1.1.24+1.21.1
 jade_version=15.10.5
 geckolib_version=QEqpUJ1G
 sable_version=2.0.0
-kaleidoscope_tavern_file_id=8083562
-kaleidoscope_tavern_version_range=[1.1.0,)
+kaleidoscope_tavern_file_id=8350856
+kaleidoscope_tavern_version_range=[1.2.0,)

--- a/src/main/java/com/yision/fluidlogistics/compat/kaleidoscopetavern/KaleidoscopeTavernCompat.java
+++ b/src/main/java/com/yision/fluidlogistics/compat/kaleidoscopetavern/KaleidoscopeTavernCompat.java
@@ -20,7 +20,7 @@ public final class KaleidoscopeTavernCompat {
     }
 
     public static boolean hasTapBehavior(BlockState sourceState) {
-        return TapBehaviorManager.contains(sourceState.getBlock());
+        return TapBehaviorManager.contains(sourceState);
     }
 
     public static @Nullable TapOperation prepare(
@@ -92,7 +92,7 @@ public final class KaleidoscopeTavernCompat {
     }
 
     private static @Nullable ITapBehavior getBehavior(BlockState sourceState) {
-        return TapBehaviorManager.get(sourceState.getBlock());
+        return TapBehaviorManager.get(sourceState);
     }
 
     private static @Nullable FluidStack mapFluidForFilter(BlockState sourceState, Predicate<FluidStack> fluidFilter) {


### PR DESCRIPTION
因 TapBehaviorManager 中的 contains/get 方法的参数发生变化，对相关兼容代码进行了调整，以修复 #60 

Closes yision1/CreateFluidLogistic#60